### PR TITLE
Added bids config file for bids-validator

### DIFF
--- a/run.py
+++ b/run.py
@@ -14,12 +14,14 @@ def run(command, env={}):
     process = subprocess.Popen(command, stdout=subprocess.PIPE,
                                stderr=subprocess.STDOUT, shell=True,
                                env=merged_env)
+
     while True:
         line = process.stdout.readline()
         line = str(line, 'utf-8')[:-1]
         print(line)
         if line == '' and process.poll() != None:
             break
+
     if process.returncode != 0:
         raise Exception("Non zero return code: %d"%process.returncode)
 
@@ -34,6 +36,7 @@ stages_dict = {"brain_extraction": "1",
 parser = argparse.ArgumentParser(description='Cortical thickness estimation using ANTs.')
 parser.add_argument('bids_dir', help='The directory with the input dataset '
                     'formatted according to the BIDS standard.')
+parser.add_argument('bids_config', help='A bids-validator configuration file.', default=None)
 parser.add_argument('output_dir', help='The directory where the output files '
                     'should be stored. If you are running group level analysis '
                     'this folder should be prepopulated with the results of the'
@@ -58,7 +61,14 @@ parser.add_argument('-v', '--version', action='version',
 
 args = parser.parse_args()
 
-run('bids-validator %s'%args.bids_dir)
+if args.bids_config is not None:
+    _bids_config = '-c {0}'.format(args.bids_config)
+else:
+    _bids_config = ' ' 
+
+run('bids-validator {0} {1}'.format(args.bids_dir, _bids_config))
+
+
 
 layout = BIDSLayout(args.bids_dir)
 

--- a/run.py
+++ b/run.py
@@ -36,7 +36,7 @@ stages_dict = {"brain_extraction": "1",
 parser = argparse.ArgumentParser(description='Cortical thickness estimation using ANTs.')
 parser.add_argument('bids_dir', help='The directory with the input dataset '
                     'formatted according to the BIDS standard.')
-parser.add_argument('bids_config', help='A bids-validator configuration file.', default=None)
+
 parser.add_argument('output_dir', help='The directory where the output files '
                     'should be stored. If you are running group level analysis '
                     'this folder should be prepopulated with the results of the'
@@ -45,6 +45,7 @@ parser.add_argument('analysis_level', help='Level of the analysis that will be p
                     'Multiple participant level analyses can be run independently '
                     '(in parallel) using the same output_dir.',
                     choices=['participant'])
+parser.add_argument('--bids_config', help='A bids-validator configuration file.', default=None)
 parser.add_argument('--participant_label', help='The label(s) of the participant(s) that should be analyzed. The label '
                    'corresponds to sub-<participant_label> from the BIDS spec '
                    '(so it does not include "sub-"). If this parameter is not '
@@ -58,7 +59,6 @@ parser.add_argument('--stage', help='Which stage of ACT to run',
 parser.add_argument('-v', '--version', action='version',
                     version='ANTs Cortical Thickness BIDS-App version {}'.format(__version__))
 
-
 args = parser.parse_args()
 
 if args.bids_config is not None:
@@ -67,8 +67,6 @@ else:
     _bids_config = ' ' 
 
 run('bids-validator {0} {1}'.format(args.bids_dir, _bids_config))
-
-
 
 layout = BIDSLayout(args.bids_dir)
 


### PR DESCRIPTION
Chris, 

I have used the antsCorticalThickness BIDS app successfully on several of my data sets.  Each time I have created a specific BIDS directory with just the T1w images so it passes the  bids-validator.  

As you know, the code checks that that BIDS directory is valid before proceeding with running antsCorticalThickness.  This works well if your BIDS directory is compliant without a configuration file. Unfortunately, for me this is normally not the case.  I use the configuration file to avoid certain issues.  

For example, when doing the heudiconv conversion the hidden directory .heudiconv is written to the BIDS directory.  This directory is not BIDS compliant and the bids-validator will fail if the directory remains.    I also like to leave README files within the BIDS directory to explain issues with the data to our group.  These README files are not BIDS compliant and the bids-validator will fail. I also like to keep the BIDS validator configuration file in the BIDS directory so people can see what is being ignored during the validation.  This file is not BIDS compliant either. 

I deal with the above examples by specifying to ignore these files and directories during the BIDS validation. This works great until I try to run antsCorticalThickness BIDS APP because it doesn't use the BIDS configuration file when performing the BIDS validation. 

I would like to recommend that either the bids-validator check is removed from the BIDS apps or the bids-validator configuration file is passed in through argparse. 

I  forked this repository and I made the suggested changes. I was able to some simple testing.  However, I am relatively new to python and I am not sure if the subprocess handles the string I am passing it to correctly.   

Please consider these simple changes. I believe that it will allow more people to use this BIDS app. 

Thanks

Bob